### PR TITLE
Allow option for cron to control the schedule of status checking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ In `settings.php` add the following:
 $config['updates_log']['diff'] = TRUE;
 ```
 
+### Control the scheduling
+
+By default, module status is checked once a day. You can delegate this to cron for custom schedule.
+
+```php
+$config['updates_log']['ultimate_control'] = TRUE;
+```
+
+
 It would produce following log:
 ```
  ---- -------------- ------------- ---------- --------------------------------------------------------

--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -22,7 +22,7 @@ class UpdatesLog {
 
     $now = time();
     $last = $this->LastGet();
-    if (!$this->ShouldUpdate($now, $last)) {
+    if (!$this->ultimateControl() && !$this->ShouldUpdate($now, $last)) {
       return;
     }
 
@@ -312,4 +312,12 @@ class UpdatesLog {
     return $diff;
   }
 
+  /**
+   * Check if running frequency should be controlled by cron job.
+   *
+   * @return bool
+   */
+  public function ultimateControl():bool {
+    return (bool) \Drupal::config('updates_log')->get('ultimate_control');
+  }
 }


### PR DESCRIPTION
Module status check schedule is hard coded in ShouldUpdate method. This makes testing the module and related alerts bit problematic as we have to wait for 24 hours before seeing any results. 

I suggest adding another setting to bypass this and essentially allow cron to decide when to execute this check.