### PR TITLE
Rename methods to comply with Drupal coding standards.

### DIFF
--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -18,43 +18,43 @@ class UpdatesLog {
   /**
    * The top-level logic of the module.
    */
-  public function Run(): void {
+  public function run(): void {
 
     $now = time();
-    $last = $this->LastGet();
-    if (!$this->ShouldUpdate($now, $last)) {
+    $last = $this->lastGet();
+    if (!$this->shouldUpdate($now, $last)) {
       return;
     }
 
-    $this->Refresh();
-    $statuses = $this->StatusesGet();
+    $this->refresh();
+    $statuses = $this->statusesGet();
     if ($this->isDiffMode()) {
       $oldStatuses = $this->statusesLoad();
       $diff = $this->computeDiff($statuses, $oldStatuses);
       if (!empty($diff)) {
-        $this->LogDiff($diff);
+        $this->logDiff($diff);
         $statuses2 = $this->statusesIntegrate($statuses, $oldStatuses);
-        $this->StatusesSave($statuses2);
+        $this->statusesSave($statuses2);
       }
     }
     else {
-      $this->LogPlain($statuses);
+      $this->logPlain($statuses);
     }
-    $this->LastSet($now);
+    $this->lastSet($now);
   }
 
   /**
-   * Decides wether it's time for logging.
+   * Decides whether it's time for logging.
    *
    * @param int $now
    *   The epoch timestamp of the now.
    * @param int $last
-   *   Last report time (spoch seconds).
+   *   Last report time (epoch seconds).
    *
    * @return bool
    *   False = don't update. True = do update.
    */
-  public function ShouldUpdate(int $now, ?int $last): bool {
+  public function shouldUpdate(int $now, ?int $last): bool {
 
     if (empty($last)) {
       return TRUE;
@@ -143,23 +143,23 @@ class UpdatesLog {
    * @return int
    *   Return int of last update time, or NULL when first time.
    */
-  public function LastGet(): ?int {
-  
+  public function lastGet(): ?int {
+
     /** @var ?mixed */
     $last = \Drupal::state()->get('updates_log.last');
-  
+
     $last = empty($last) ? NULL : intval($last);
-  
+
     return $last;
   }
-  
+
   /**
    * Set the last update time.
    *
    * @param int $time
    *   Set update last time logged.
    */
-  public function LastSet(?int $time): void {
+  public function lastSet(?int $time): void {
     \Drupal::state()->set('updates_log.last', $time);
   }
 
@@ -169,7 +169,7 @@ class UpdatesLog {
    * @param array $statuses
    *   Statuses to save.
    */
-  public function StatusesSave(array $statuses): void {
+  public function statusesSave(array $statuses): void {
     \Drupal::state()->set('updates_log.statuses', $statuses);
   }
 
@@ -179,9 +179,8 @@ class UpdatesLog {
    * @return array
    *   Statuses of last time.
    */
-  public function StatusesLoad(): array {
-    $statuses = \Drupal::state()->get('updates_log.statuses', []);
-    return $statuses;
+  public function statusesLoad(): array {
+    return \Drupal::state()->get('updates_log.statuses', []);
   }
 
   /*
@@ -194,7 +193,7 @@ class UpdatesLog {
    * @param array<string, string> $statuses
    *   An associative array of ['module_name' => 'status_string'].
    */
-  public function LogPlain(array $statuses): void {
+  public function logPlain(array $statuses): void {
     $logger = \Drupal::logger('updates_log');
     foreach ($statuses as $project => $status) {
       // Drupal logging cannot handle json in any way.
@@ -214,7 +213,7 @@ class UpdatesLog {
    * @param array<string, array<string, string>> $statuses
    *   An associative array of ['module_name' => ['old' => 'status_string', 'new' => 'status_string']].
    */
-  public function LogDiff(array $statuses): void {
+  public function logDiff(array $statuses): void {
     $logger = \Drupal::logger('updates_log');
     foreach ($statuses as $project => $status) {
       // Drupal logging cannot handle json in any way.
@@ -238,7 +237,7 @@ class UpdatesLog {
    *
    * Ripped from update_cron().
    */
-  public function Refresh(): void {
+  public function refresh(): void {
 
     if (!empty(getenv('TESTING'))) {
       // We cannot boot properly from external script.
@@ -258,7 +257,7 @@ class UpdatesLog {
    * @return array<string, string>
    *   Return array of ['module_name' => 'status_string'].
    */
-  public function StatusesGet(): array {
+  public function statusesGet(): array {
 
     $map = [
 
@@ -308,8 +307,7 @@ class UpdatesLog {
    *   True if diff mode, false otherwise.
    */
   public function isDiffMode(): bool {
-    $diff = (bool) \Drupal::config('updates_log')->get('diff');
-    return $diff;
+    return (bool) \Drupal::config('updates_log')->get('diff');
   }
 
 }

--- a/tests/HookTest.php
+++ b/tests/HookTest.php
@@ -19,7 +19,7 @@ class HookTest extends TestCase {
   public function testCrash(): void {
 
     $m = new UpdatesLog();
-    $m->LastSet(NULL);
+    $m->lastSet(NULL);
 
     // Make sure we wont crash.
     updates_log_cron();

--- a/tests/LastTest.php
+++ b/tests/LastTest.php
@@ -14,8 +14,8 @@ class LastTest extends TestCase {
    */
   public function testNull(): void {
     $m = new UpdatesLog();
-    $m->LastSet(NULL);
-    $timestamp = $m->LastGet();
+    $m->lastSet(NULL);
+    $timestamp = $m->lastGet();
     $this->assertNull($timestamp);
   }
 
@@ -26,8 +26,8 @@ class LastTest extends TestCase {
   public function testNumeric(): void {
     $m = new UpdatesLog();
     $now = time();
-    $m->LastSet($now);
-    $timestamp = $m->LastGet();
+    $m->lastSet($now);
+    $timestamp = $m->lastGet();
     $this->assertIsInt($timestamp);
     $this->assertEquals($now, $timestamp);
   }

--- a/tests/LogDiffTest.php
+++ b/tests/LogDiffTest.php
@@ -18,7 +18,7 @@ class LogDiffTest extends TestCase {
     $m = new UpdatesLog();
     $database = \Drupal::database();
     $database->truncate('watchdog')->execute();
-    $m->LogDiff($statuses);
+    $m->logDiff($statuses);
     $query = $database->query("select * from {watchdog}");
     $result = $query->fetchAll();
     $log = reset($result);

--- a/tests/LogPlainTest.php
+++ b/tests/LogPlainTest.php
@@ -18,7 +18,7 @@ class LogPlainTest extends TestCase {
     $m = new UpdatesLog();
     $database = \Drupal::database();
     $database->truncate('watchdog')->execute();
-    $m->LogPlain($statuses);
+    $m->logPlain($statuses);
     $query = $database->query("select * from {watchdog}");
     $result = $query->fetchAll();
     $log = reset($result);

--- a/tests/RefreshTest.php
+++ b/tests/RefreshTest.php
@@ -13,7 +13,7 @@ class RefreshTest extends TestCase {
    */
   public function testCrash(): void {
     $m = new UpdatesLog();
-    $m->Refresh();
+    $m->refresh();
     $this->assertTrue(TRUE);
   }
 

--- a/tests/RunTest.php
+++ b/tests/RunTest.php
@@ -13,7 +13,7 @@ class RunTest extends TestCase {
    */
   public function testCrash(): void {
     $m = new UpdatesLog();
-    $m->Run();
+    $m->run();
     $this->assertTrue(TRUE);
   }
 

--- a/tests/ShouldUpdateTest.php
+++ b/tests/ShouldUpdateTest.php
@@ -13,7 +13,7 @@ class ShouldUpdateTest extends TestCase {
    */
   public function testFirstTime(): void {
     $m = new UpdatesLog();
-    $status = $m->ShouldUpdate(time(), NULL);
+    $status = $m->shouldUpdate(time(), NULL);
     $this->assertTrue($status);
   }
 
@@ -22,7 +22,7 @@ class ShouldUpdateTest extends TestCase {
    */
   public function testImmediately(): void {
     $m = new UpdatesLog();
-    $status = $m->ShouldUpdate(time(), time() + 1);
+    $status = $m->shouldUpdate(time(), time() + 1);
     $this->assertFalse($status);
   }
 
@@ -31,7 +31,7 @@ class ShouldUpdateTest extends TestCase {
    */
   public function testLater(): void {
     $m = new UpdatesLog();
-    $status = $m->ShouldUpdate(time(), time() - 24 * 60 * 60);
+    $status = $m->shouldUpdate(time(), time() - 24 * 60 * 60);
     $this->assertTrue($status);
   }
 

--- a/tests/StatusesGetTest.php
+++ b/tests/StatusesGetTest.php
@@ -13,7 +13,7 @@ class StatusesGetTest extends TestCase {
    */
   public function testStructure(): void {
     $m = new UpdatesLog();
-    $statuses = $m->StatusesGet();
+    $statuses = $m->statusesGet();
     $expected = [
       'drupal' => 'CURRENT',
     ];

--- a/tests/StatusesLoadSaveTest.php
+++ b/tests/StatusesLoadSaveTest.php
@@ -15,15 +15,15 @@ class StatusesLoadSaveTest extends TestCase {
   public function testStatusesLoadSave(): void {
 
     $m = new UpdatesLog();
-    
+
     \Drupal::state()->delete('updates_log.statuses');
 
-    $statuses = $m->StatusesLoad();
+    $statuses = $m->statusesLoad();
     $this->assertEquals([], $statuses);
 
     $statuses = ['x' => 'y'];
-    $m->StatusesSave($statuses);
-    $statuses2 = $m->StatusesLoad();
+    $m->statusesSave($statuses);
+    $statuses2 = $m->statusesLoad();
     $this->assertEquals($statuses, $statuses2);
 
     \Drupal::state()->delete('updates_log.statuses');

--- a/updates_log.module
+++ b/updates_log.module
@@ -16,5 +16,5 @@ use Drupal\updates_log\UpdatesLog;
  */
 function updates_log_cron(): void {
   $module = new UpdatesLog();
-  $module->Run();
+  $module->run();
 }


### PR DESCRIPTION
Drupal coding standards suggest that we should be using lowerCamel case method names: https://www.drupal.org/docs/develop/standards/object-oriented-code#naming