### PR TITLE
Add dynamic versioning. Add Site and Env info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,21 @@ The "prefix" (`updates_log_statistics=`) is there to help filter and parse the d
 
 ## Development of `updates_log`
 
-For Development, I suggest the [drupal-project](https://github.com/wunderio/drupal-project) as a base.
-
+- Clone [drupal-project](https://github.com/wunderio/drupal-project) as a base
+- Clone `updates_log` project into `web/modules/custom/updates_log`
+- Edit `.lando.yml` to disable unneeded services and their proxies (`chrome`, `elasticsearch`, `kibana`, `mailhog`, `node`)
 - `lando start` - Start up the development environment
-- clone this project into `web/modules/custom/updates_log`
-- `lando drush en updates_log` enable the module
+- `lando drush site-install` - Populate the database
+- `lando drush en updates_log` - Enable the module
 - `lando drush cron` or
   - ssh into the container `lando ssh` and run `UPDATES_LOG_TEST=1 drush cron` to bypass the time checks
 - `lando grumphp run` for code scanning
 - `lando phpunit --group=updates_log` for running tests
+
+### Making releases
+
+* Update the `updates_log.info.yml`
+* Create a release with the same version in the GitHub.
 
 ## Debugging - What to do when you don't see expected results?
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ It is detected by using first non-empty item:
 
 ### Env
 
-The `site` identifies environment (dev, staging, producion, etc).
+The `env` identifies environment (dev, staging, producion, etc).
 It is detected by using first non-empty item:
 - Env `ENVIRONMENT_NAME`
 - Env `WKV_SITE_ENV`

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The "prefix" (`updates_log_statistics=`) is there to help filter and parse the d
 - Clone `updates_log` project into `web/modules/custom/updates_log`
 - Edit `.lando.yml` to disable unneeded services and their proxies (`chrome`, `elasticsearch`, `kibana`, `mailhog`, `node`)
 - `lando start` - Start up the development environment
+- `lando composer install` - Install GrumPHP
 - `lando drush site-install` - Populate the database
 - `lando drush en updates_log` - Enable the module
 - `lando drush cron` or
@@ -127,8 +128,11 @@ The "prefix" (`updates_log_statistics=`) is there to help filter and parse the d
 
 ### Making releases
 
+* Make sure all changes have tests
+* Make sure all tests pass
+* Maks sure code scan is clean
 * Update the `updates_log.info.yml`
-* Create a release with the same version in the GitHub.
+* Create a release with the same version in the GitHub
 
 ## Debugging - What to do when you don't see expected results?
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Status codes are taken from the Drupal code:
   - `CURRENT`
 
 - `web/core/modules/update/src/UpdateFetcherInterface.php`
-  - `???` (`NOT_CHECKED`)
-  - `???` (`UNKNOWN`)
-  - `???` (`NOT_FETCHED`)
-  - `???` (`FETCH_PENDING`)
+  - `NOT_CHECKED`
+  - `UNKNOWN`
+  - `NOT_FETCHED`
+  - `FETCH_PENDING`
 
 ## Timing
 
@@ -90,10 +90,12 @@ Every state change will have its own log entry.
 The module also logs "Statistics" once in 24h that gives a quick overview about how many modules there are and in what statuses.
 ```
 updates_log_statistics={
-  "updates_log": "2.0",
+  "updates_log": "2.0.1",
   "last_check_epoch": 1672835445,
   "last_check_human": "2023-01-04T12:30:450GMT",
   "last_check_ago": 16,
+  "site": "project-acme-support",
+  "env": "prod",
   "summary": {
     "CURRENT": 31,
     "NOT_CURRENT": 0,
@@ -111,6 +113,24 @@ updates_log_statistics={
 ```
 
 The "prefix" (`updates_log_statistics=`) is there to help filter and parse the data from the log entry.
+
+### Site
+
+The `site` identifies project.
+It is detected by using first non-empty item:
+- Env `PROJECT_NAME`
+- Env `HOSTNAME`
+- Env `DRUSH_OPTIONS_URI` + hostname extraction
+- `"unknown"`
+
+### Env
+
+The `site` identifies environment (dev, staging, producion, etc).
+It is detected by using first non-empty item:
+- Env `ENVIRONMENT_NAME`
+- Env `WKV_SITE_ENV`
+- Settings `simple_environment_indicator` + color removal
+- `"unknown"`
 
 ## Development of `updates_log`
 
@@ -130,8 +150,9 @@ The "prefix" (`updates_log_statistics=`) is there to help filter and parse the d
 
 * Make sure all changes have tests
 * Make sure all tests pass
-* Maks sure code scan is clean
-* Update the `updates_log.info.yml`
+* Make sure code scan is clean
+* Update `README.md`
+* Update `version` in the `updates_log.info.yml`
 * Create a release with the same version in the GitHub
 
 ## Debugging - What to do when you don't see expected results?

--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\updates_log;
 
+use Drupal\Core\Extension\ExtensionList;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\Core\Site\Settings;
@@ -58,6 +59,13 @@ class UpdatesLog {
   private UpdateProcessorInterface $updateProcessor;
 
   /**
+   * The ExtensionList.
+   *
+   * @var \Drupal\Core\Extension\ExtensionList
+   */
+  private ExtensionList $extensionList;
+
+  /**
    * UpdatesLog constructor.
    *
    * @param \Drupal\Core\State\StateInterface $state
@@ -68,18 +76,22 @@ class UpdatesLog {
    *   The UpdateManagerInterface.
    * @param \Drupal\update\UpdateProcessorInterface $updateProcessor
    *   The UpdateProcessorInterface.
+   * @param \Drupal\Core\Extension\ExtensionList $moduleExtensionList
+   *   The ExtensionList.
    */
   public function __construct(
     StateInterface $state,
     LoggerChannelFactoryInterface $loggerChannelFactory,
     UpdateManagerInterface $updateManager,
-    UpdateProcessorInterface $updateProcessor
+    UpdateProcessorInterface $updateProcessor,
+    ExtensionList $moduleExtensionList
   ) {
     $this->state = $state;
     $this->logger = $loggerChannelFactory->get('updates_log');
     $this->updateManager = $updateManager;
     $this->updateProcessor = $updateProcessor;
     $this->lastUpdated = $state->get('update.last_check', 0);
+    $this->extensionList = $moduleExtensionList;
   }
 
   /*
@@ -310,7 +322,7 @@ class UpdatesLog {
    *   A version string like "1.2.3".
    */
   public function getVersion(): string {
-    $data = \Drupal::service('extension.list.module')->getExtensionInfo('updates_log');
+    $data = $this->extensionList->getExtensionInfo('updates_log');
     $version = $data['version'];
     return $version;
   }

--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -108,7 +108,8 @@ class UpdatesLog {
       $this->state->set(self::STATUSES_STATE, $new_statuses);
     }
     if (getenv('UPDATES_LOG_TEST') || ($now >= $this->getLastRanStatistics() + (60 * 60 * 24))) {
-      $statistics = $this->generateStatistics($statuses);
+      $version = $this->getVersion();
+      $statistics = $this->generateStatistics($statuses, $version);
       $this->logStatistics($statistics);
       $this->state->set(self::STATISTICS_TIME_STATE, $now);
     }
@@ -291,6 +292,18 @@ class UpdatesLog {
   }
 
   /**
+   * Fetch version string of updates_log module itself.
+   *
+   * @return string
+   *   A version string like "1.2.3".
+   */
+  public function getVersion(): string {
+    $data = \Drupal::service('extension.list.module')->getExtensionInfo('updates_log');
+    $version = $data['version'];
+    return $version;
+  }
+
+  /**
    * Generates "Statistics" of module states and versions.
    *
    * @param array $statuses
@@ -299,9 +312,9 @@ class UpdatesLog {
    * @return array
    *   The statistics array.
    */
-  public function generateStatistics(array $statuses): array {
+  public function generateStatistics(array $statuses, string $version): array {
     $statistics = [
-      "updates_log" => "2.0",
+      "updates_log" => $version,
       "last_check_epoch" => $this->lastUpdated,
       "last_check_human" => gmdate('Y-m-d\Th:i:sZT', $this->lastUpdated),
       "last_check_ago" => time() - $this->lastUpdated,

--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -266,7 +266,11 @@ class UpdatesLog {
 
     $available = update_get_available(TRUE);
 
-    /** @var array<string, array{status: int}> $available */
+    // Function update_calculate_project_data not found.
+    /**
+     * @phpstan-ignore-next-line
+     * @var array<string, array{status: int}> $available
+     */
     $project_data = update_calculate_project_data($available);
 
     ksort($project_data);
@@ -308,6 +312,8 @@ class UpdatesLog {
    *
    * @param array $statuses
    *   An array of statuses.
+   * @param string $version
+   *   The versin of UpdatesLog.
    *
    * @return array
    *   The statistics array.

--- a/tests/src/Kernel/GetEnvTest.php
+++ b/tests/src/Kernel/GetEnvTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace tests\src\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\updates_log\UpdatesLog;
+
+/**
+ * Tests detacing the website env (dev, stage, prod, etc).
+ *
+ * @group updates_log
+ */
+class GetEnvTest extends KernelTestBase {
+
+  /**
+   * The UpdatesLog service.
+   *
+   * @var \Drupal\updates_log\UpdatesLog
+   */
+  private UpdatesLog $updatesLogService;
+
+  /**
+   * The modules to load to run the test.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'update',
+    'updates_log',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['updates_log']);
+    $this->updatesLogService = \Drupal::service('updates_log.updates_logger');
+  }
+
+  /**
+   * @covers ::getEnv
+   */
+  public function testGetEnvEnvironmentName(): void {
+    $value = 'xxx';
+    putenv("ENVIRONMENT_NAME=$value");
+    putenv("WKV_SITE_ENV");
+    $env = $this->updatesLogService->getEnv();
+    $this->assertEquals($value, $env);
+  }
+
+  /**
+   * @covers ::getEnv
+   */
+  public function testGetEnvWkvSiteEnv(): void {
+    $value = 'xxx';
+    putenv("ENVIRONMENT_NAME");
+    putenv("WKV_SITE_ENV=$value");
+    $env = $this->updatesLogService->getEnv();
+    $this->assertEquals($value, $env);
+  }
+
+  // It is too hard to test Settings::get('simple_environment_indicator')
+
+  /**
+   * @covers ::getEnv
+   */
+  public function testGetEnvUnknown(): void {
+    $value = 'unknown';
+    putenv("ENVIRONMENT_NAME");
+    putenv("WKV_SITE_ENV");
+    $env = $this->updatesLogService->getEnv();
+    $this->assertEquals($value, $env);
+  }
+
+}

--- a/tests/src/Kernel/GetSiteTest.php
+++ b/tests/src/Kernel/GetSiteTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace tests\src\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\updates_log\UpdatesLog;
+
+/**
+ * Tests that fetching the version of updates_log.
+ *
+ * @group updates_log
+ */
+class GetSiteTest extends KernelTestBase {
+
+  /**
+   * The UpdatesLog service.
+   *
+   * @var \Drupal\updates_log\UpdatesLog
+   */
+  private UpdatesLog $updatesLogService;
+
+  /**
+   * The modules to load to run the test.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'update',
+    'updates_log',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['updates_log']);
+    $this->updatesLogService = \Drupal::service('updates_log.updates_logger');
+  }
+
+  /**
+   * @covers ::getSite
+   */
+  public function testGetSiteProjectName(): void {
+    $value = 'xxx';
+    putenv("PROJECT_NAME=$value");
+    putenv("HOSTNAME");
+    putenv("DRUSH_OPTIONS_URI");
+    $site = $this->updatesLogService->getSite();
+    $this->assertEquals($value, $site);
+  }
+
+  /**
+   * @covers ::getSite
+   */
+  public function testGetSiteHostname(): void {
+    $value = 'xxx';
+    putenv("PROJECT_NAME");
+    putenv("HOSTNAME=$value");
+    putenv("DRUSH_OPTIONS_URI");
+    $site = $this->updatesLogService->getSite();
+    $this->assertEquals($value, $site);
+  }
+
+  /**
+   * @covers ::getSite
+   */
+  public function testGetSiteDrushOptionsUri(): void {
+    $value = 'xxx';
+    putenv("PROJECT_NAME");
+    putenv("HOSTNAME=$value");
+    putenv("DRUSH_OPTIONS_URI=https://$value/yyy");
+    $site = $this->updatesLogService->getSite();
+    $this->assertEquals($value, $site);
+  }
+
+  /**
+   * @covers ::getSite
+   */
+  public function testGetSiteUnknown(): void {
+    $value = 'unknown';
+    putenv("PROJECT_NAME");
+    putenv("HOSTNAME=$value");
+    putenv("DRUSH_OPTIONS_URI");
+    $site = $this->updatesLogService->getSite();
+    $this->assertEquals($value, $site);
+  }
+
+}

--- a/tests/src/Kernel/GetVersionTest.php
+++ b/tests/src/Kernel/GetVersionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace tests\src\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\updates_log\UpdatesLog;
+
+/**
+ * Tests that fetching the version of updates_log.
+ *
+ * @group updates_log
+ */
+class RunTest extends KernelTestBase {
+
+  /**
+   * The UpdatesLog service.
+   *
+   * @var \Drupal\updates_log\UpdatesLog
+   */
+  private UpdatesLog $updatesLogService;
+
+  /**
+   * The modules to load to run the test.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'updates_log',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['updates_log']);
+    $this->updatesLogService = \Drupal::service('updates_log.updates_logger');
+  }
+
+  /**
+   * @covers ::getVersion
+   */
+  public function testGetVersion(): void {
+      $version = $this->updatesLogService->getVersion();
+      $this->assertMatchesRegularExpression('/^\d+\.\d+\.\d+$/', $version);
+  }
+
+}

--- a/tests/src/Kernel/GetVersionTest.php
+++ b/tests/src/Kernel/GetVersionTest.php
@@ -25,6 +25,7 @@ class RunTest extends KernelTestBase {
    * @var array
    */
   protected static $modules = [
+    'update',
     'updates_log',
   ];
 

--- a/tests/src/Kernel/GetVersionTest.php
+++ b/tests/src/Kernel/GetVersionTest.php
@@ -10,7 +10,7 @@ use Drupal\updates_log\UpdatesLog;
  *
  * @group updates_log
  */
-class RunTest extends KernelTestBase {
+class GetVersionTest extends KernelTestBase {
 
   /**
    * The UpdatesLog service.
@@ -42,8 +42,8 @@ class RunTest extends KernelTestBase {
    * @covers ::getVersion
    */
   public function testGetVersion(): void {
-      $version = $this->updatesLogService->getVersion();
-      $this->assertMatchesRegularExpression('/^\d+\.\d+\.\d+$/', $version);
+    $version = $this->updatesLogService->getVersion();
+    $this->assertMatchesRegularExpression('/^\d+\.\d+\.\d+$/', $version);
   }
 
 }

--- a/tests/src/Kernel/GetVersionTest.php
+++ b/tests/src/Kernel/GetVersionTest.php
@@ -6,7 +6,7 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\updates_log\UpdatesLog;
 
 /**
- * Tests that fetching the version of updates_log.
+ * Tests fetching the version of updates_log.
  *
  * @group updates_log
  */

--- a/tests/src/Kernel/UpdatesLogRunTest.php
+++ b/tests/src/Kernel/UpdatesLogRunTest.php
@@ -8,9 +8,11 @@ use Drupal\updates_log\UpdatesLog;
 /**
  * Tests that UpdatesLog does not crash during full run.
  *
+ * NB! RunTest is already reserved.
+ *
  * @group updates_log
  */
-class RunTest extends KernelTestBase {
+class UpdatesLogRunTest extends KernelTestBase {
 
   /**
    * The UpdatesLog service.

--- a/tests/src/Unit/GenerateStatisticsTest.php
+++ b/tests/src/Unit/GenerateStatisticsTest.php
@@ -14,6 +14,7 @@ class GenerateStatisticsTest extends UpdatesLogTestBase {
    * @covers ::generateStatistics
    */
   public function testGenerateStatistics(): void {
+    $version = "1.2.3";
     $statistics = $this->updatesLog->generateStatistics(
       [
         'x' => ['status' => 'NOT_CURRENT', 'version_used' => 'x'],
@@ -23,7 +24,8 @@ class GenerateStatisticsTest extends UpdatesLogTestBase {
         'b' => ['status' => 'CURRENT', 'version_used' => 'x'],
         'c' => ['status' => '???', 'version_used' => 'x'],
 
-      ]
+      ],
+      $version
     );
     $this->assertEquals(2, $statistics['summary']['CURRENT']);
     $this->assertEquals(1, $statistics['summary']['NOT_CURRENT']);
@@ -31,6 +33,7 @@ class GenerateStatisticsTest extends UpdatesLogTestBase {
     $this->assertCount(4, $statistics['details']);
     $this->assertArrayHasKey('NOT_SECURE', $statistics['details']);
     $this->assertArrayHasKey('NOT_SUPPORTED', $statistics['details']);
+    $this->assertEquals($version, $statistics['updates_log']);
   }
 
 }

--- a/tests/src/Unit/GenerateStatisticsTest.php
+++ b/tests/src/Unit/GenerateStatisticsTest.php
@@ -15,6 +15,8 @@ class GenerateStatisticsTest extends UpdatesLogTestBase {
    */
   public function testGenerateStatistics(): void {
     $version = "1.2.3";
+    $site = 'acme-support-web';
+    $env = 'staging';
     $statistics = $this->updatesLog->generateStatistics(
       [
         'x' => ['status' => 'NOT_CURRENT', 'version_used' => 'x'],
@@ -25,7 +27,9 @@ class GenerateStatisticsTest extends UpdatesLogTestBase {
         'c' => ['status' => '???', 'version_used' => 'x'],
 
       ],
-      $version
+      $version,
+      $site,
+      $env
     );
     $this->assertEquals(2, $statistics['summary']['CURRENT']);
     $this->assertEquals(1, $statistics['summary']['NOT_CURRENT']);
@@ -34,6 +38,8 @@ class GenerateStatisticsTest extends UpdatesLogTestBase {
     $this->assertArrayHasKey('NOT_SECURE', $statistics['details']);
     $this->assertArrayHasKey('NOT_SUPPORTED', $statistics['details']);
     $this->assertEquals($version, $statistics['updates_log']);
+    $this->assertEquals($site, $statistics['site']);
+    $this->assertEquals($env, $statistics['env']);
   }
 
 }

--- a/tests/src/Unit/UpdatesLogTestBase.php
+++ b/tests/src/Unit/UpdatesLogTestBase.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\updates_log\Unit;
 
+use Drupal\Core\Extension\ExtensionList;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\State\State;
 use Drupal\Tests\UnitTestCase;
@@ -47,6 +48,7 @@ abstract class UpdatesLogTestBase extends UnitTestCase {
     $logger_factory = $this->prophet->prophesize(LoggerChannelFactoryInterface::class);
     $update_manager = $this->prophet->prophesize(UpdateManagerInterface::class);
     $update_processor = $this->prophet->prophesize(UpdateProcessorInterface::class);
+    $module_extension_list = $this->prophet->prophesize(ExtensionList::class);
 
     // When doing \Drupal::logger('updates_log') return the mock logger.
     // @codingStandardsIgnoreStart
@@ -65,7 +67,8 @@ abstract class UpdatesLogTestBase extends UnitTestCase {
       $state->reveal(),
       $logger_factory->reveal(),
       $update_manager->reveal(),
-      $update_processor->reveal()
+      $update_processor->reveal(),
+      $module_extension_list->reveal()
     );
   }
 

--- a/updates_log.info.yml
+++ b/updates_log.info.yml
@@ -4,5 +4,6 @@ description: "Log module update info"
 core: 8.x
 core_version_requirement: ^8 || ^9 || ^10
 package: Development
+version: 2.0.1
 dependencies:
   - drupal:update

--- a/updates_log.services.yml
+++ b/updates_log.services.yml
@@ -1,4 +1,4 @@
 services:
   updates_log.updates_logger:
     class: Drupal\updates_log\UpdatesLog
-    arguments: [ '@state', '@logger.factory', '@update.manager', '@update.processor' ]
+    arguments: [ '@state', '@logger.factory', '@update.manager', '@update.processor', '@extension.list.module' ]


### PR DESCRIPTION
The version is dynamically acquired from Drupal and it is not hardcoded anymore in the code.
The reason for this is better tracking in log analysis - how to treat the data.

There are included `site` and `env` key-pairs in statistics.