### PR TITLE
Handle core bug: sometimes Drupal is not able to fetch module versions.

### DIFF
--- a/tests/src/Kernel/LogUnknownTest.php
+++ b/tests/src/Kernel/LogUnknownTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace tests\src\Kernel;
+
+use Drupal\Core\Database\Connection;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\updates_log\UpdatesLog;
+
+/**
+ * @coversDefaultClass \Drupal\updates_log\UpdatesLog
+ * @group updates_log
+ */
+class LogUnknownTest extends KernelTestBase {
+
+  /**
+   * The UpdatesLog service.
+   *
+   * @var \Drupal\updates_log\UpdatesLog
+   */
+  private UpdatesLog $updatesLogService;
+
+  /**
+   * The Database Connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  private Connection $db;
+
+  /**
+   * The modules to load to run the test.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'update',
+    'updates_log',
+    'dblog',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installConfig(['updates_log']);
+    $this->installSchema('dblog', ['watchdog']);
+    $this->updatesLogService = \Drupal::service('updates_log.updates_logger');
+    $this->db = \Drupal::database();
+  }
+
+  /**
+   * @covers ::logDiff
+   */
+  public function testLogUnknown(): void {
+
+    $this->db->truncate('watchdog')->execute();
+    $this->updatesLogService->logUnknown();
+    $query = $this->db->query("select * from {watchdog}");
+    $result = $query->fetchAll();
+    $log = reset($result);
+
+    $this->assertEquals('updates_log', $log->type);
+    $this->assertEquals(4, $log->severity);
+    $this->assertGreaterThan(time() - 5, $log->timestamp);
+  }
+
+}

--- a/tests/src/Kernel/RunDiffTest.php
+++ b/tests/src/Kernel/RunDiffTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace tests\src\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\updates_log\UpdatesLog;
+
+/**
+ * Test diff handling.
+ *
+ * @group updates_log
+ */
+class RunDiffTest extends KernelTestBase {
+
+  /**
+   * The UpdatesLog service.
+   *
+   * @var \Drupal\updates_log\UpdatesLog
+   */
+  private UpdatesLog $updatesLogService;
+
+  /**
+   * The modules to load to run the test.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'update',
+    'updates_log',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['updates_log']);
+    $this->updatesLogService = \Drupal::service('updates_log.updates_logger');
+  }
+
+  /**
+   * @covers ::runDiff
+   */
+  public function testNoChanges(): void {
+
+    // Old.
+    $statuses_old = ['projX' => 'a'];
+    \Drupal::state()->set(
+        UpdatesLog::STATUSES_STATE,
+        $statuses_old
+    );
+
+    // New.
+    $statuses_new = ['projX' => ['status' => 'a']];
+
+    $this->updatesLogService->runDiff($statuses_new);
+
+    $statuses_updated = \Drupal::state()->get(
+        UpdatesLog::STATUSES_STATE
+    );
+
+    $this->assertEquals($statuses_old, $statuses_updated);
+  }
+
+  /**
+   * @covers ::runDiff
+   */
+  public function testYesChanges(): void {
+
+    // Old.
+    $statuses_old = ['projX' => 'a'];
+    \Drupal::state()->set(
+        UpdatesLog::STATUSES_STATE,
+        $statuses_old
+    );
+
+    // New.
+    $statuses_new = ['projX' => ['status' => 'b']];
+
+    $this->updatesLogService->runDiff($statuses_new);
+
+    $statuses_updated = \Drupal::state()->get(
+        UpdatesLog::STATUSES_STATE
+    );
+
+    // Expected.
+    $statuses_expected = ['projX' => 'b'];
+
+    $this->assertEquals($statuses_expected, $statuses_updated);
+  }
+
+}

--- a/tests/src/Kernel/RunStatisticsTest.php
+++ b/tests/src/Kernel/RunStatisticsTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace tests\src\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\updates_log\UpdatesLog;
+
+/**
+ * Test statistics handling.
+ *
+ * @group updates_log
+ */
+class RunStatisticsTest extends KernelTestBase {
+
+  /**
+   * The UpdatesLog service.
+   *
+   * @var \Drupal\updates_log\UpdatesLog
+   */
+  private UpdatesLog $updatesLogService;
+
+  /**
+   * The modules to load to run the test.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'update',
+    'updates_log',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['updates_log']);
+    $this->updatesLogService = \Drupal::service('updates_log.updates_logger');
+  }
+
+  /**
+   * @covers ::runStatistics
+   */
+  public function testEnvCondition(): void {
+    \Drupal::state()->set(
+        UpdatesLog::STATISTICS_TIME_STATE,
+        time()
+    );
+    putenv('UPDATES_LOG_TEST=1');
+    $status = $this->updatesLogService->runStatistics([], time());
+    $this->assertNotEquals(1, $status);
+  }
+
+  /**
+   * @covers ::runStatistics
+   */
+  public function testTimeCondition(): void {
+    \Drupal::state()->set(
+        UpdatesLog::STATISTICS_TIME_STATE,
+        time() - (60 * 60 * 24)
+    );
+    putenv('UPDATES_LOG_TEST');
+    $status = $this->updatesLogService->runStatistics([], time());
+    $this->assertNotEquals(1, $status);
+  }
+
+  /**
+   * @covers ::runStatistics
+   */
+  public function testBothCondition(): void {
+    \Drupal::state()->set(
+        UpdatesLog::STATISTICS_TIME_STATE,
+        time() - (60 * 60 * 24)
+    );
+    putenv('UPDATES_LOG_TEST=1');
+    $status = $this->updatesLogService->runStatistics([], time());
+    $this->assertNotEquals(1, $status);
+  }
+
+  /**
+   * @covers ::runStatistics
+   */
+  public function testNoCondition(): void {
+    \Drupal::state()->set(
+        UpdatesLog::STATISTICS_TIME_STATE,
+        time()
+    );
+    putenv('UPDATES_LOG_TEST');
+    $status = $this->updatesLogService->runStatistics([], time());
+    $this->assertEquals(1, $status);
+  }
+
+  /**
+   * @covers ::runStatistics
+   */
+  public function testUnknown(): void {
+    \Drupal::state()->set(
+        UpdatesLog::STATISTICS_TIME_STATE,
+        time() - (60 * 60 * 24)
+    );
+    putenv('UPDATES_LOG_TEST=1');
+    $statuses = [
+      'projX' => [
+        'status' => '???',
+        'version_used' => '1.2.3',
+      ],
+    ];
+    $status = $this->updatesLogService->runStatistics($statuses, time());
+    $this->assertEquals(2, $status);
+  }
+
+  /**
+   * @covers ::runStatistics
+   */
+  public function testNotUnknown(): void {
+    \Drupal::state()->set(
+        UpdatesLog::STATISTICS_TIME_STATE,
+        time() - (60 * 60 * 24)
+    );
+    putenv('UPDATES_LOG_TEST=1');
+    $statuses = [
+      'projX' => [
+        'status' => 'CURRENT',
+        'version_used' => '1.2.3',
+      ],
+    ];
+    $status = $this->updatesLogService->runStatistics($statuses, time());
+    $this->assertNotEquals(2, $status);
+  }
+
+  /**
+   * @covers ::runStatistics
+   */
+  public function testSuccess(): void {
+    $time = time();
+    \Drupal::state()->set(
+        UpdatesLog::STATISTICS_TIME_STATE,
+        $time - (60 * 60 * 24)
+    );
+    putenv('UPDATES_LOG_TEST=1');
+    $statuses = [
+      'projX' => [
+        'status' => 'CURRENT',
+        'version_used' => '1.2.3',
+      ],
+    ];
+    $status = $this->updatesLogService->runStatistics($statuses, $time);
+    $this->assertEquals(0, $status);
+
+    $time_updated = \Drupal::state()->get(
+        UpdatesLog::STATISTICS_TIME_STATE
+    );
+    $this->assertEquals($time, $time_updated);
+
+  }
+
+}

--- a/updates_log.info.yml
+++ b/updates_log.info.yml
@@ -4,6 +4,6 @@ description: "Log module update info"
 core: 8.x
 core_version_requirement: ^8 || ^9 || ^10
 package: Development
-version: 2.0.1
+version: 2.0.2
 dependencies:
   - drupal:update


### PR DESCRIPTION
Here is the update.
Did a bit of refactoring too: moved diff and stats handling into separate functions.
It allows much better testing.