### PR TITLE
Proper JSON termination.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ As an alternative there is Warden, but it lacks highly configurable alerting.
 On hourly basis it logs the differences of the statuses of modules like this (if there are any changes):
 
 ```
- ---- -------------- ------------- ---------- -------------------------------------------------------------------
+ ---- -------------- ------------- ---------- ---------------------------------------------------------------------
   ID   Date           Type          Severity   Message
- ---- -------------- ------------- ---------- -------------------------------------------------------------------
-  1    01/Jul 15:43   updates_log   Info      updates_log={"project":"drupal","old":"CURRENT","new":"NOT_SECURE"}
- ---- -------------- ------------- ---------- -------------------------------------------------------------------
+ ---- -------------- ------------- ---------- ---------------------------------------------------------------------
+  1    01/Jul 15:43   updates_log   Info      updates_log={"project":"drupal","old":"CURRENT","new":"NOT_SECURE"}==
+ ---- -------------- ------------- ---------- ---------------------------------------------------------------------
 ```
 
 `old` and `new` denote statuses.
@@ -71,7 +71,11 @@ The diff log entries may be generated as often as once per hour.
 
 `updates_log.statuses` - Module "current" statuses are kept in this state variable. Required to be able to perform diff. To observe the contents of it run the following command: `drush sget updates_log.statuses --format=json`.
 
-## Output: Diff
+## Output
+
+The generic format is `id={json}==`. There are two equal-signs at the end to mark the end of the JSON. It is needed, because in some logging environment there is additional encapsulation used which makes parsing impossible.
+
+### Diff
 
 When there are any changes in module statuses, then their output in the logs looks as follows:
 
@@ -80,12 +84,12 @@ updates_log={
   project: "webform",
   old: "NOT_CURRENT",
   new: "CURRENT"
-}
+}==
 ```
 
 Every state change will have its own log entry.
 
-## Output: Statistics
+### Statistics
 
 The module also logs "Statistics" once in 24h that gives a quick overview about how many modules there are and in what statuses.
 ```
@@ -109,7 +113,7 @@ updates_log_statistics={
        "admin_toolbar": "3.1.0"
     }
   }
-}
+}==
 ```
 
 The "prefix" (`updates_log_statistics=`) is there to help filter and parse the data from the log entry.

--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -290,7 +290,7 @@ class UpdatesLog {
       catch (\Exception $exception) {
         $json = $exception->getMessage();
       }
-      $this->logger->info('updates_log=@placeholder', ["@placeholder" => $json]);
+      $this->logger->info('updates_log=@placeholder==', ["@placeholder" => $json]);
     }
   }
 
@@ -504,7 +504,7 @@ class UpdatesLog {
     catch (\Exception $exception) {
       $json = $exception->getMessage();
     }
-    $this->logger->info('updates_log_statistics=@placeholder', ["@placeholder" => $json]);
+    $this->logger->info('updates_log_statistics=@placeholder==', ["@placeholder" => $json]);
   }
 
   /**

--- a/tests/src/Kernel/LogTest.php
+++ b/tests/src/Kernel/LogTest.php
@@ -63,7 +63,7 @@ class LogTest extends KernelTestBase {
     $log = reset($result);
 
     $this->assertEquals('updates_log', $log->type);
-    $this->assertEquals('updates_log=@placeholder', $log->message);
+    $this->assertEquals('updates_log=@placeholder==', $log->message);
     $this->assertEquals('a:1:{s:12:"@placeholder";s:44:"{"project":"drupal","old":"old","new":"new"}";}', $log->variables);
     $this->assertEquals(6, $log->severity);
     $this->assertGreaterThan(time() - 5, $log->timestamp);
@@ -104,7 +104,7 @@ class LogTest extends KernelTestBase {
     $log = reset($result);
 
     $this->assertEquals('updates_log', $log->type);
-    $this->assertEquals('updates_log_statistics=@placeholder', $log->message);
+    $this->assertEquals('updates_log_statistics=@placeholder==', $log->message);
     $this->assertEquals('a:1:{s:12:"@placeholder";s:497:"{"updates_log":"2.0","last_check_epoch":' . $time . ',"last_check_human":"' . gmdate('Y-m-d\Th:i:sZT', $time) . '","last_check_ago":1,"summary":{"CURRENT":2,"NOT_CURRENT":1,"NOT_SECURE":0,"NOT_SUPPORTED":1,"REVOKED":0,"UNKNOWN":1},"details":{"x":{"status":"NOT_CURRENT","version_used":"x"},"y":{"status":"NOT_SUPPORTED","version_used":"x"},"z":{"status":"NOT_SECURE","version_used":"x"},"a":{"status":"CURRENT","version_used":"x"},"b":{"status":"CURRENT","version_used":"x"},"c":{"status":"???","version_used":"x"}}}";}', $log->variables);
     $this->assertEquals(6, $log->severity);
     $this->assertGreaterThan(time() - 5, $log->timestamp);

--- a/updates_log.info.yml
+++ b/updates_log.info.yml
@@ -4,6 +4,6 @@ description: "Log module update info"
 core: 8.x
 core_version_requirement: ^8 || ^9 || ^10
 package: Development
-version: 2.0.2
+version: 2.0.3
 dependencies:
   - drupal:update


### PR DESCRIPTION
Some systems do additional JSON encapsulation to logs, which makes it hard to separate our JSON from the rest.
Therefore add an additional terminator at the end of the JSON string.