### PR TITLE
Add setting to "disable" reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ It is detected by using first non-empty item:
 - Settings `simple_environment_indicator` + color removal
 - `"unknown"`
 
-### Settings
+## Settings
 
 You can add `$settings['updates_log_disabled'] = TRUE;` in your `settings.php` to stop updates_log from reporting.
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ It is detected by using first non-empty item:
 - Settings `simple_environment_indicator` + color removal
 - `"unknown"`
 
+### Settings
+
+You can add `$settings['updates_log_disabled'] = TRUE;` in your `settings.php` to stop updates_log from reporting.
+
+This is useful for sites that want to report updates in only one environment.
+
 ## Development of `updates_log`
 
 - Clone [drupal-project](https://github.com/wunderio/drupal-project) as a base

--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -105,7 +105,7 @@ class UpdatesLog {
 
     $now = time();
     $last = $this->getLastRan();
-    if (!$this->shouldUpdate($now, $last)) {
+    if (!$this->shouldUpdate($now, $last) || Settings::get('updates_log_disabled', FALSE)) {
       return;
     }
 

--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -102,10 +102,12 @@ class UpdatesLog {
    * The top-level logic of the module.
    */
   public function run(): void {
-
+    if (Settings::get('updates_log_disabled', FALSE)) {
+      return;
+    }
     $now = time();
     $last = $this->getLastRan();
-    if (!$this->shouldUpdate($now, $last) || Settings::get('updates_log_disabled', FALSE)) {
+    if (!$this->shouldUpdate($now, $last)) {
       return;
     }
 

--- a/tests/src/Kernel/GetEnvTest.php
+++ b/tests/src/Kernel/GetEnvTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\src\Kernel;
+namespace Drupal\Tests\updates_log\Kernel;
 
 use Drupal\Core\Site\Settings;
 use Drupal\KernelTests\KernelTestBase;

--- a/tests/src/Kernel/GetSiteTest.php
+++ b/tests/src/Kernel/GetSiteTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\src\Kernel;
+namespace Drupal\Tests\updates_log\Kernel;
 
 use Drupal\Core\Site\Settings;
 use Drupal\KernelTests\KernelTestBase;

--- a/tests/src/Kernel/GetVersionTest.php
+++ b/tests/src/Kernel/GetVersionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\src\Kernel;
+namespace Drupal\Tests\updates_log\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\updates_log\UpdatesLog;

--- a/tests/src/Kernel/HookTest.php
+++ b/tests/src/Kernel/HookTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\src\Kernel;
+namespace Drupal\Tests\updates_log\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\updates_log\UpdatesLog;

--- a/tests/src/Kernel/LogTest.php
+++ b/tests/src/Kernel/LogTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\src\Kernel;
+namespace Drupal\Tests\updates_log\Kernel;
 
 use Drupal\Core\Database\Connection;
 use Drupal\KernelTests\KernelTestBase;

--- a/tests/src/Kernel/LogUnknownTest.php
+++ b/tests/src/Kernel/LogUnknownTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\src\Kernel;
+namespace Drupal\Tests\updates_log\Kernel;
 
 use Drupal\Core\Database\Connection;
 use Drupal\KernelTests\KernelTestBase;

--- a/tests/src/Kernel/RunDiffTest.php
+++ b/tests/src/Kernel/RunDiffTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\src\Kernel;
+namespace Drupal\Tests\updates_log\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\updates_log\UpdatesLog;

--- a/tests/src/Kernel/RunStatisticsTest.php
+++ b/tests/src/Kernel/RunStatisticsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\src\Kernel;
+namespace Drupal\Tests\updates_log\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\updates_log\UpdatesLog;

--- a/tests/src/Kernel/UpdatesLogDisabledTest.php
+++ b/tests/src/Kernel/UpdatesLogDisabledTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\updates_log\Kernel;
 
 use Drupal\Core\Site\Settings;
+use Drupal\Core\Database\Connection;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\updates_log\UpdatesLog;
 
@@ -19,6 +20,13 @@ class UpdatesLogDisabledTest extends KernelTestBase {
    * @var \Drupal\updates_log\UpdatesLog
    */
   private UpdatesLog $updatesLogService;
+
+  /**
+   * The Database Connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  private Connection $db;
 
   /**
    * The modules to load to run the test.
@@ -42,6 +50,9 @@ class UpdatesLogDisabledTest extends KernelTestBase {
     $this->db = \Drupal::database();
   }
 
+  /**
+   * Test that there is no output when disabled = TRUE.
+   */
   public function testDisabledDoesNotRun(): void {
     new Settings(['updates_log_disabled' => TRUE]);
     $this->updatesLogService->run();
@@ -51,8 +62,9 @@ class UpdatesLogDisabledTest extends KernelTestBase {
   }
 
   /**
-   * @return void
-   * @depends  Drupal\Tests\updates_log\Kernel\UpdatesLogRunTest::testCrash
+   * If UpdatesLogRunTest::testCrash is good then we know this works.
+   *
+   * @depends Drupal\Tests\updates_log\Kernel\UpdatesLogRunTest::testCrash
    */
   public function testNotDisabledRuns(): void {
     $this->assertTrue(TRUE);

--- a/tests/src/Kernel/UpdatesLogDisabledTest.php
+++ b/tests/src/Kernel/UpdatesLogDisabledTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\Tests\updates_log\Kernel;
+
+use Drupal\Core\Site\Settings;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\updates_log\UpdatesLog;
+
+/**
+ * Tests that "updates_log_disabled" setting works as expected.
+ *
+ * @group updates_log
+ */
+class UpdatesLogDisabledTest extends KernelTestBase {
+
+  /**
+   * The UpdatesLog service.
+   *
+   * @var \Drupal\updates_log\UpdatesLog
+   */
+  private UpdatesLog $updatesLogService;
+
+  /**
+   * The modules to load to run the test.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'update',
+    'updates_log',
+    'dblog',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['updates_log']);
+    $this->installSchema('dblog', ['watchdog']);
+    $this->updatesLogService = \Drupal::service('updates_log.updates_logger');
+    $this->db = \Drupal::database();
+  }
+
+  public function testDisabledDoesNotRun(): void {
+    new Settings(['updates_log_disabled' => TRUE]);
+    $this->updatesLogService->run();
+    $query = $this->db->query("select * from {watchdog}");
+    $result = $query->fetchAll();
+    $this->assertEmpty($result);
+  }
+
+  /**
+   * @return void
+   * @depends  Drupal\Tests\updates_log\Kernel\UpdatesLogRunTest::testCrash
+   */
+  public function testNotDisabledRuns(): void {
+    $this->assertTrue(TRUE);
+  }
+
+}

--- a/tests/src/Kernel/UpdatesLogRunTest.php
+++ b/tests/src/Kernel/UpdatesLogRunTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\src\Kernel;
+namespace Drupal\Tests\updates_log\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\updates_log\UpdatesLog;

--- a/tests/src/Unit/GenerateStatisticsTest.php
+++ b/tests/src/Unit/GenerateStatisticsTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace tests\src\Unit;
-
-use Drupal\Tests\updates_log\Unit\UpdatesLogTestBase;
+namespace Drupal\Tests\updates_log\Unit;
 
 /**
  * @coversDefaultClass \Drupal\updates_log\UpdatesLog

--- a/updates_log.info.yml
+++ b/updates_log.info.yml
@@ -4,6 +4,6 @@ description: "Log module update info"
 core: 8.x
 core_version_requirement: ^8 || ^9 || ^10
 package: Development
-version: 2.1.1
+version: 2.2.1
 dependencies:
   - drupal:update


### PR DESCRIPTION
Some projects do not want to Add "config_split" to choose in which env Updates_log is working.

This is an easy way to "Select" which env can report

Also "fixed" the Namespaces in the `tests` folder