### PR TITLE
Fix occasionally missing notifications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Here are few more things to try:
 - Drupal `update` module:
   - Make sure `/admin/reports/updates/settings` loads, and is configured
   - Check the status at "Available updates" report. Is it red or green?
-  - `drush eval 'var_dump(update_get_available(TRUE));` - should return large array.
+  - `drush eval 'var_dump(update_get_available(TRUE));'` - should return large array.
   - `drush eval '$available = update_get_available(TRUE); $project_data = update_calculate_project_data($available); var_dump($project_data);'`
   - `drush ev '\Drupal::keyValue("update_fetch_task")->deleteAll();'` - after `update` reinstall
   - `drush sqlq 'truncate batch'`

--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -113,6 +113,10 @@ class UpdatesLog {
 
     $this->refresh();
     $statuses = $this->statusesGet();
+    if (empty($statuses)) {
+      $this->logUnknown();
+      return;
+    }
 
     $this->runDiff($statuses);
     $this->runStatistics($statuses, $now);
@@ -316,7 +320,7 @@ class UpdatesLog {
    * Get module statuses from Drupal.
    *
    * @return array
-   *   Return array of statuses.
+   *   Return array of statuses. Will be an empty array if Drupal is messed up.
    */
   public function statusesGet(): array {
 
@@ -337,6 +341,9 @@ class UpdatesLog {
     ];
 
     $available = update_get_available(TRUE);
+    if (empty($available)) {
+      return [];
+    }
 
     // Function update_calculate_project_data not found.
     /**

--- a/tests/src/Kernel/StatusesGetTest.php
+++ b/tests/src/Kernel/StatusesGetTest.php
@@ -35,6 +35,7 @@ class StatusesGetTest extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
     $this->installConfig(['updates_log']);
+    $this->installConfig(['update']);
     $this->updatesLogService = \Drupal::service('updates_log.updates_logger');
   }
 

--- a/updates_log.info.yml
+++ b/updates_log.info.yml
@@ -4,6 +4,6 @@ description: "Log module update info"
 core: 8.x
 core_version_requirement: ^8 || ^9 || ^10
 package: Development
-version: 2.2.1
+version: 2.2.2
 dependencies:
   - drupal:update


### PR DESCRIPTION
Don't try to `runDiff()` and `runStatistics()` when we are not getting anything from `update_get_available()`.
It is especially bad that it would update the timestamp when there is no data.