### PR TITLE
Allow testing when Updates_log is "disabled" in settings.php

### DIFF
--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -102,9 +102,6 @@ class UpdatesLog {
    * The top-level logic of the module.
    */
   public function run(): void {
-    if (Settings::get('updates_log_disabled', FALSE)) {
-      return;
-    }
     $now = time();
     $last = $this->getLastRan();
     if (!$this->shouldUpdate($now, $last)) {
@@ -204,7 +201,13 @@ class UpdatesLog {
    *   False = don't update. True = do update.
    */
   public function shouldUpdate(int $now, ?int $last): bool {
-    if ($last === NULL || getenv('UPDATES_LOG_TEST')) {
+    if (getenv('UPDATES_LOG_TEST')) {
+      return TRUE;
+    }
+    if (Settings::get('updates_log_disabled', FALSE)) {
+      return FALSE;
+    }
+    if ($last === NULL) {
       return TRUE;
     }
     // Run every hour.

--- a/tests/src/Kernel/UpdatesLogDisabledTest.php
+++ b/tests/src/Kernel/UpdatesLogDisabledTest.php
@@ -48,13 +48,15 @@ class UpdatesLogDisabledTest extends KernelTestBase {
     $this->installSchema('dblog', ['watchdog']);
     $this->updatesLogService = \Drupal::service('updates_log.updates_logger');
     $this->db = \Drupal::database();
+    putenv("UPDATES_LOG_TEST");
+
   }
 
   /**
    * Test that there is no output when disabled = TRUE.
    */
   public function testDisabledDoesNotRun(): void {
-    new Settings(['updates_log_disabled' => TRUE]);
+    new Settings(['updates_log_disabled' => TRUE, 'hash_salt' => 'notsosecurehash']);
     $this->updatesLogService->run();
     $query = $this->db->query("select * from {watchdog}");
     $result = $query->fetchAll();

--- a/updates_log.info.yml
+++ b/updates_log.info.yml
@@ -4,6 +4,6 @@ description: "Log module update info"
 core: 8.x
 core_version_requirement: ^8 || ^9 || ^10
 package: Development
-version: 2.2.2
+version: 2.3.2
 dependencies:
   - drupal:update

--- a/updates_log.info.yml
+++ b/updates_log.info.yml
@@ -4,6 +4,6 @@ description: "Log module update info"
 core: 8.x
 core_version_requirement: ^8 || ^9 || ^10
 package: Development
-version: 2.3.2
+version: 2.3.0
 dependencies:
   - drupal:update


### PR DESCRIPTION
The change checks if we are in "testing" first
Then checks if updates_log is disabled in settings.php

This allows us to test updates_log in envs that have it disabled by settings.php (F.ex the "automated" PR script envs )