### PR TITLE
Do not check updates if UpdateManager already contains data

### DIFF
--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -349,10 +349,12 @@ class UpdatesLog {
       -3 => 'NOT_FETCHED',
       -4 => 'FETCH_PENDING',
     ];
-
-    $available = update_get_available(TRUE);
+    $available = $this->updateManager->getProjects();
     if (empty($available)) {
-      return [];
+      $available = update_get_available(TRUE);
+      if (empty($available)) {
+        return [];
+      }
     }
 
     // Function update_calculate_project_data not found.


### PR DESCRIPTION
The current problem is when update_cron is run then the `update_get_available(TRUE);` is used and there are "projects" in the `updateProcessor` so when we run it a bit later the "projects" are still there and the data is not updated "again" since it already exists

The fix is to check if there are any "projects" in the `updateProcessor` and if not then we run the `update_get_available`

