### PR TITLE
Notifications: JSON: Site & Env: Include

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ As an alternative there is Warden, but it lacks highly configurable alerting.
 On hourly basis it logs the differences of the statuses of modules like this (if there are any changes):
 
 ```
- ---- -------------- ------------- ---------- ---------------------------------------------------------------------
+ ---- -------------- ------------- ---------- ------------------------------------------------------------------------------------------------------
   ID   Date           Type          Severity   Message
- ---- -------------- ------------- ---------- ---------------------------------------------------------------------
-  1    01/Jul 15:43   updates_log   Info      updates_log={"project":"drupal","old":"CURRENT","new":"NOT_SECURE"}==
- ---- -------------- ------------- ---------- ---------------------------------------------------------------------
+ ---- -------------- ------------- ---------- ------------------------------------------------------------------------------------------------------
+  1    01/Jul 15:43   updates_log   Info      updates_log={"project":"drupal","old":"CURRENT","new":"NOT_SECURE","site":"example.com","env:"prod"}==
+ ---- -------------- ------------- ---------- ------------------------------------------------------------------------------------------------------
 ```
 
 `old` and `new` denote statuses.
@@ -87,6 +87,8 @@ updates_log={
   project: "webform",
   old: "NOT_CURRENT",
   new: "CURRENT"
+  site: "example.com"
+  env: "prod"
 }==
 ```
 
@@ -97,7 +99,7 @@ Every state change will have its own log entry.
 The module also logs "Statistics" once in 24h that gives a quick overview about how many modules there are and in what statuses.
 ```
 updates_log_statistics={
-  "updates_log": "2.0.1",
+  "updates_log": "2.4.0",
   "last_check_epoch": 1672835445,
   "last_check_human": "2023-01-04T12:30:450GMT",
   "last_check_ago": 16,

--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -66,6 +66,20 @@ class UpdatesLog {
   private ExtensionList $extensionList;
 
   /**
+   * The Site name.
+   *
+   * @var string
+   */
+  private string $site;
+
+  /**
+   * The Env name.
+   *
+   * @var string
+   */
+  private string $env;
+
+  /**
    * UpdatesLog constructor.
    *
    * @param \Drupal\Core\State\StateInterface $state
@@ -92,6 +106,9 @@ class UpdatesLog {
     $this->updateProcessor = $updateProcessor;
     $this->lastUpdated = $state->get('update.last_check', 0);
     $this->extensionList = $moduleExtensionList;
+
+    $this->site = $this->getSite();
+    $this->env = $this->getEnv();
   }
 
   /*
@@ -168,13 +185,11 @@ class UpdatesLog {
     }
 
     $version = $this->getVersion();
-    $site = $this->getSite();
-    $env = $this->getEnv();
     $statistics = $this->generateStatistics(
       $statuses,
       $version,
-      $site,
-      $env
+      $this->site,
+      $this->env
     );
 
     // https://www.drupal.org/project/drupal/issues/2920285
@@ -292,6 +307,8 @@ class UpdatesLog {
         'project' => $project,
         'old' => $status['old'],
         'new' => $status['new'],
+        'site' => $this->site,
+        'env' => $this->env,
       ];
       try {
         $json = json_encode($log, JSON_THROW_ON_ERROR);

--- a/tests/src/Kernel/LogTest.php
+++ b/tests/src/Kernel/LogTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\updates_log\Kernel;
 
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Site\Settings;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\updates_log\UpdatesLog;
 
@@ -43,6 +44,11 @@ class LogTest extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
 
+    new Settings([
+      'updates_log_site' => 'site',
+      'updates_log_env' => 'env',
+    ]);
+
     $this->installConfig(['updates_log']);
     $this->installSchema('dblog', ['watchdog']);
     $this->updatesLogService = \Drupal::service('updates_log.updates_logger');
@@ -64,7 +70,7 @@ class LogTest extends KernelTestBase {
 
     $this->assertEquals('updates_log', $log->type);
     $this->assertEquals('updates_log=@placeholder==', $log->message);
-    $this->assertEquals('a:1:{s:12:"@placeholder";s:44:"{"project":"drupal","old":"old","new":"new"}";}', $log->variables);
+    $this->assertEquals('a:1:{s:12:"@placeholder";s:70:"{"project":"drupal","old":"old","new":"new","site":"site","env":"env"}";}', $log->variables);
     $this->assertEquals(6, $log->severity);
     $this->assertGreaterThan(time() - 5, $log->timestamp);
   }

--- a/updates_log.info.yml
+++ b/updates_log.info.yml
@@ -4,6 +4,6 @@ description: "Log module update info"
 core: 8.x
 core_version_requirement: ^8 || ^9 || ^10
 package: Development
-version: 2.3.1
+version: 2.4.0
 dependencies:
   - drupal:update


### PR DESCRIPTION
**The problem**

Having logs of multiple systems does not allow us to make a good common alert, because it's hard to tell which site and env generated the notification.

**The cause**

The notifications do not contain the site, not the env information.

**The goal**

The notification contains site and env info.

**The solution**

- Add the site and env info into notifications.
- Improve tests.