### PR TITLE
QAG-53: Log current modules too

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Every state change will have its own log entry.
 The module also logs "Statistics" once in 24h that gives a quick overview about how many modules there are and in what statuses.
 ```
 updates_log_statistics={
-  "updates_log": "2.4.0",
+  "updates_log": "2.5.0",
   "last_check_epoch": 1672835445,
   "last_check_human": "2023-01-04T12:30:450GMT",
   "last_check_ago": 16,

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,5 @@
     "composer/composer": "^2",
     "drupal/core": "^9 || ^10"
   },
-  "version": "2.4.2"
+  "version": "2.5.0"
 }

--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -558,10 +558,6 @@ class UpdatesLog {
         $statistics['summary']['UNKNOWN'] += 1;
       }
 
-      if ($status === 'CURRENT') {
-        continue;
-      }
-
       $statistics['details'][$status][$project] = $data['version_used'];
     }
 


### PR DESCRIPTION
We add logging for all modules, then we can see versions of arbitrary modules.
There is a risk also that entries get too big and systems won't handle them.