### PR TITLE
QAG-69: Use: Namespace: Paths: Fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,5 @@
     "composer/composer": "^2",
     "drupal/core": "^9 || ^10 || ^11"
   },
-  "version": "2.5.5"
+  "version": "2.5.6"
 }

--- a/src/UpdatesLog.php
+++ b/src/UpdatesLog.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\updates_log;
 
 use Composer\Json\JsonFile;
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Datetime\TimeInterface;
 use Drupal\Core\Extension\ExtensionList;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\State\StateInterface;
 use Drupal\Core\Site\Settings;
+use Drupal\Core\State\StateInterface;
 use Drupal\update\UpdateManagerInterface;
 use Drupal\update\UpdateProcessorInterface;
 use Psr\Log\LoggerInterface;
@@ -178,7 +178,7 @@ class UpdatesLog {
   /**
    * The top-level logic of the module.
    *
-   * @param array $statuses
+   * @param array<string, array{status: string, version_used: string}> $statuses
    *   The statuses array.
    */
   public function runDiff(
@@ -200,7 +200,7 @@ class UpdatesLog {
   /**
    * The top-level logic of the module.
    *
-   * @param array $statuses
+   * @param array<string, array{status: string, version_used: string}> $statuses
    *   The statuses array.
    * @param int $now
    *   The now timestamp.
@@ -269,12 +269,12 @@ class UpdatesLog {
   /**
    * Compute old and new status differences.
    *
-   * @param array $new
+   * @param array<string, array{status: string, version_used: string}> $new
    *   New statuses.
-   * @param array $old
+   * @param array<string, string> $old
    *   Old statuses.
    *
-   * @return array
+   * @return array<string, array{old: string, new: string}>
    *   Statuses diff.
    */
   public function computeDiff(array $new, array $old): array {
@@ -304,12 +304,12 @@ class UpdatesLog {
   /**
    * Integrate old and new statuses in a safe way.
    *
-   * @param array $new
+   * @param array<string, array{status: string, version_used: string}> $new
    *   New statuses.
-   * @param array $old
+   * @param array<string, string> $old
    *   Old statuses.
    *
-   * @return array
+   * @return array<string, string>
    *   Integrated statuses.
    */
   public function statusesIntegrate(array $new, array $old): array {
@@ -334,7 +334,7 @@ class UpdatesLog {
   /**
    * Log the modules, and statuses.
    *
-   * @param array[] $statuses
+   * @param array<string, array{old: string, new: string}> $statuses
    *   An associative array of ['module_name' => ['old' => 'status_string',
    *   'new' => 'status_string']].
    */
@@ -415,7 +415,7 @@ class UpdatesLog {
   /**
    * Get module statuses from Drupal.
    *
-   * @return array
+   * @return array<string, array{status: string, version_used: string}>
    *   Return array of statuses. Will be an empty array if Drupal is messed up.
    */
   public function statusesGet(): array {
@@ -554,16 +554,26 @@ class UpdatesLog {
   /**
    * Generates "Statistics" of module states and versions.
    *
-   * @param array $statuses
+   * @param array<string, array{status: string, version_used: string}> $statuses
    *   An array of statuses.
    * @param string $version
-   *   The versin of UpdatesLog.
+   *   The version of UpdatesLog.
    * @param string $site
-   *   The the Drupal project id, for example acme-support-web.
+   *   The Drupal project id, for example acme-support-web.
    * @param string $env
    *   The environment, for example dev, stg, prod.
    *
-   * @return array
+   * @return array{
+   *   updates_log: string,
+   *   site: string,
+   *   env: string,
+   *   last_check_epoch: int,
+   *   last_check_human: string,
+   *   last_check_ago: int,
+   *   drupal: string,
+   *   summary: array<string, int>,
+   *   details: array<string, array<string, string>>
+   * }
    *   The statistics array.
    */
   public function generateStatistics(
@@ -617,7 +627,17 @@ class UpdatesLog {
   /**
    * Logs the given Statistics in json using the Logger.
    *
-   * @param array $statistics
+   * @param array{
+   *   updates_log: string,
+   *   site: string,
+   *   env: string,
+   *   last_check_epoch: int,
+   *   last_check_human: string,
+   *   last_check_ago: int,
+   *   drupal: string,
+   *   summary: array<string, int>,
+   *   details: array<string, array<string, string>>
+   * } $statistics
    *   The statistics array.
    */
   public function logStatistics(array $statistics): void {

--- a/tests/src/Unit/GenerateStatisticsTest.php
+++ b/tests/src/Unit/GenerateStatisticsTest.php
@@ -32,7 +32,7 @@ class GenerateStatisticsTest extends UpdatesLogTestBase {
     $this->assertEquals(3, $statistics['summary']['CURRENT']);
     $this->assertEquals(1, $statistics['summary']['NOT_CURRENT']);
     $this->assertEquals(1, $statistics['summary']['UNKNOWN']);
-    $this->assertCount(4, $statistics['details']);
+    $this->assertCount(5, $statistics['details']);
     $this->assertArrayHasKey('NOT_SECURE', $statistics['details']);
     $this->assertArrayHasKey('NOT_SUPPORTED', $statistics['details']);
     $this->assertEquals($version, $statistics['updates_log']);

--- a/tests/src/Unit/UpdatesLogTestBase.php
+++ b/tests/src/Unit/UpdatesLogTestBase.php
@@ -2,8 +2,12 @@
 
 namespace Drupal\Tests\updates_log\Unit;
 
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Extension\ExtensionList;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Extension\ModuleHandler;
 use Drupal\Core\State\State;
 use Drupal\Tests\UnitTestCase;
 use Drupal\update\UpdateManagerInterface;
@@ -11,7 +15,6 @@ use Drupal\update\UpdateProcessorInterface;
 use Drupal\updates_log\UpdatesLog;
 use Prophecy\Argument;
 use Prophecy\Prophet;
-use Drupal\Core\Logger\LoggerChannelInterface;
 
 /**
  * @coversDefaultClass \Drupal\updates_log\UpdatesLog
@@ -49,6 +52,9 @@ abstract class UpdatesLogTestBase extends UnitTestCase {
     $update_manager = $this->prophet->prophesize(UpdateManagerInterface::class);
     $update_processor = $this->prophet->prophesize(UpdateProcessorInterface::class);
     $module_extension_list = $this->prophet->prophesize(ExtensionList::class);
+    $module_handler = $this->prophet->prophesize(ModuleHandler::class);
+    $config_factory = $this->prophet->prophesize(ConfigFactoryInterface::class);
+    $time_if = $this->prophet->prophesize(TimeInterface::class);
 
     // When doing \Drupal::logger('updates_log') return the mock logger.
     // @codingStandardsIgnoreStart
@@ -68,7 +74,10 @@ abstract class UpdatesLogTestBase extends UnitTestCase {
       $logger_factory->reveal(),
       $update_manager->reveal(),
       $update_processor->reveal(),
-      $module_extension_list->reveal()
+      $module_extension_list->reveal(),
+      $module_handler->reveal(),
+      $config_factory->reveal(),
+      $time_if->reveal(),
     );
   }
 


### PR DESCRIPTION
# The problem

```text
Drupalupdates_logUpdatesLog::__construct(): Argument #8 ($time) must be of type DrupalCoreDatetimeTimeInterface, DrupalComponentDatetimeTime given
```

# Changes

* Fix `use` namespaces
* Fix tests
* Add type hints

# Release checklist

- [x] Make sure all changes have tests
- [x] Make sure all tests pass
- [x] Make sure code scan is clean
- [x] Update `README.md`
- [x] Update Drupal Project template if needed
- [x] Update `version` in the `composer.json`
- [ ] Create a release with the same version in the GitHub
- [ ] Check version validation workflow in GiHub Actions
